### PR TITLE
Bump path-parse from 1.0.6 to 1.0.7

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5833,9 +5833,9 @@ path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
 
 path-parse@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
-  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-root-regex@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
### Description

In this pull request, the version of the `path-parse` package in the `yarn.lock` file has been updated from 1.0.6 to 1.0.7.

Changes:
- Updated the version of the `path-parse` package from 1.0.6 to 1.0.7.
- Updated the resolved URL of the `path-parse` package to point to version 1.0.7.
- Updated the integrity checksum for the `path-parse` package.

This pull request contains a small dependency update for the `path-parse` package.