### PR TITLE
Bump pathval from 1.1.0 to 1.1.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5864,9 +5864,9 @@ path-type@^1.0.0:
     pinkie-promise "^2.0.0"
 
 pathval@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
-  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
 pbkdf2@^3.0.17:
   version "3.1.1"


### PR DESCRIPTION
### Description

In this pull request, the version of the 'pathval' package is being updated from 1.1.0 to 1.1.1 in the yarn.lock file.

Changes:
- Update the version of the 'pathval' package from 1.1.0 to 1.1.1.
- The package's resolved URL is also updated.
- The integrity hash of the package is also updated.